### PR TITLE
Config file for Read The Docs

### DIFF
--- a/docs/.readthedocs.yaml
+++ b/docs/.readthedocs.yaml
@@ -1,0 +1,28 @@
+# Read the Docs configuration file for Sphinx projects
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Set the OS, Python version and other tools you might need
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.12"
+
+# Build documentation in the "docs/" directory with Sphinx
+sphinx:
+  configuration: docs/conf.py
+
+# Optionally build your docs in additional formats such as PDF and ePub
+formats: all
+
+# Optional but recommended, declare the Python requirements required
+# to build your documentation
+# See https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
+python:
+  install:
+    - method: pip
+      path: .
+      extra_requirements:
+        - docs


### PR DESCRIPTION
This adds a configuration file to the `docs/` directory for Read The Docs. When setting up the project on the Read The Docs website, the following need to be considered:
- Set the path to the config file to `docs/.readthedocs.yaml`; otherwise, Read The Docs will look in the root directory of the project for the configuration
- Set latest to the dev branch and stable to the main branch

This resolves #170 to make the documentation viewable online.