### PR TITLE
renamed append in subclass to match parent

### DIFF
--- a/src/flowcept/commons/daos/mq_dao/mq_dao_base.py
+++ b/src/flowcept/commons/daos/mq_dao/mq_dao_base.py
@@ -70,7 +70,6 @@ class MQDao(ABC):
         self._keyvalue_dao = KeyValueDAO()
         self._time_based_flushing_started = False
         self.buffer: Union[AutoflushBuffer, List] = None
-
         self._flush_events = []
 
     @abstractmethod

--- a/src/flowcept/commons/daos/mq_dao/mq_dao_kafka.py
+++ b/src/flowcept/commons/daos/mq_dao/mq_dao_kafka.py
@@ -29,7 +29,6 @@ class MQDaoKafka(MQDao):
         }
         self._producer = Producer(self._kafka_conf)
         self._consumer = None
-        self.flush_events = []
 
     def subscribe(self):
         """Subscribe to the interception channel."""
@@ -71,7 +70,7 @@ class MQDaoKafka(MQDao):
         t1 = time()
         self._producer.flush()
         t2 = time()
-        self.flush_events.append(["single",t1,t2,t2 - t1, len(str(message).encode())])
+        self._flush_events.append(["single",t1,t2,t2 - t1, len(str(message).encode())])
 
     def _bulk_publish(self, buffer, channel=MQ_CHANNEL, serializer=msgpack.dumps):
         total = 0
@@ -91,7 +90,7 @@ class MQDaoKafka(MQDao):
             t1 = time()
             self._producer.flush()
             t2 = time()
-            self.flush_events.append(["bulk", t1,t2,t2 - t1,total])
+            self._flush_events.append(["bulk", t1,t2,t2 - t1,total])
 
             self.logger.info(f"Flushed {len(buffer)} msgs to MQ!")
         except Exception as e:

--- a/src/flowcept/commons/daos/mq_dao/mq_dao_mofka.py
+++ b/src/flowcept/commons/daos/mq_dao/mq_dao_mofka.py
@@ -22,7 +22,6 @@ class MQDaoMofka(MQDao):
     def __init__(self, adapter_settings=None, with_producer=True):
         super().__init__(adapter_settings=adapter_settings)
         self.producer = None
-        self.flush_events = []
         if with_producer:
             print("Starting producer")
             self.producer = MQDaoMofka._topic.producer(
@@ -60,7 +59,7 @@ class MQDaoMofka(MQDao):
         t1 = time()
         self.producer.flush()
         t2 = time()
-        self.flush_events.append(["single",t1,t2,t2 - t1, len(str(message).encode())])
+        self._flush_events.append(["single",t1,t2,t2 - t1, len(str(message).encode())])
         
     
 
@@ -84,7 +83,7 @@ class MQDaoMofka(MQDao):
             t1 = time()
             self.producer.flush()
             t2 = time()
-            self.flush_events.append(["bulk", t1,t2,t2 - t1,total])
+            self._flush_events.append(["bulk", t1,t2,t2 - t1,total])
 
             self.logger.info(f"Flushed {len(buffer)} msgs to MQ!")
         except Exception as e:

--- a/src/flowcept/commons/daos/mq_dao/mq_dao_redis.py
+++ b/src/flowcept/commons/daos/mq_dao/mq_dao_redis.py
@@ -23,7 +23,6 @@ class MQDaoRedis(MQDao):
         super().__init__(adapter_settings)
         self._producer = self._keyvalue_dao.redis_conn  # if MQ is redis, we use the same KV for the MQ
         self._consumer = None
-        self.flush_events = []
         
     def subscribe(self):
         """
@@ -64,7 +63,7 @@ class MQDaoRedis(MQDao):
         t1 = time()
         self._producer.publish(channel, serializer(message))
         t2 = time()
-        self.flush_events.append(["single",t1,t2,t2 - t1, len(str(message).encode())])
+        self._flush_events.append(["single",t1,t2,t2 - t1, len(str(message).encode())])
 
     def _bulk_publish(self, buffer, channel=MQ_CHANNEL, serializer=msgpack.dumps):
         total = 0
@@ -84,7 +83,7 @@ class MQDaoRedis(MQDao):
             t1 = time()
             pipe.execute()
             t2 = time()
-            self.flush_events.append(["bulk", t1,t2,t2 - t1,total])
+            self._flush_events.append(["bulk", t1,t2,t2 - t1,total])
             self.logger.debug(f"Flushed {len(buffer)} msgs to MQ!")
         except Exception as e:
             self.logger.exception(e)


### PR DESCRIPTION
All the flushes from the child class would not be recorded b/c the list was name `self.flush_events` in the child and `self._flush_events` in the parent. I also removed the list init from the child so they don't overwrite each other.