### PR TITLE
Fix mq_dao_mofka for current mofka@main API

### DIFF
--- a/src/flowcept/commons/daos/mq_dao/mq_dao_mofka.py
+++ b/src/flowcept/commons/daos/mq_dao/mq_dao_mofka.py
@@ -15,7 +15,7 @@ from flowcept.configs import MQ_SETTINGS, MQ_CHANNEL
 class MQDaoMofka(MQDao):
     """Main class to communicate with Mofka."""
 
-    _driver = mofka.MofkaDriver(MQ_SETTINGS.get("group_file", None), use_progress_thread=True)
+    _driver = mofka.MofkaDriver(group_file=MQ_SETTINGS.get("group_file",None))
     _topic = _driver.open_topic(MQ_SETTINGS["channel"])
 
     def __init__(self, adapter_settings=None, with_producer=True):
@@ -26,16 +26,13 @@ class MQDaoMofka(MQDao):
             self.producer = MQDaoMofka._topic.producer(
                 "p" + MQ_CHANNEL,
                 batch_size=mofka.AdaptiveBatchSize,
-                thread_pool=mofka.ThreadPool(1),
                 ordering=mofka.Ordering.Strict,
             )
 
     def subscribe(self):
         """Subscribe to Mofka topic."""
-        batch_size = AdaptiveBatchSize
-        thread_pool = ThreadPool(0)
         self.consumer = MQDaoMofka._topic.consumer(
-            name=MQ_CHANNEL + str(uuid.uuid4()), thread_pool=thread_pool, batch_size=batch_size
+            name=MQ_CHANNEL + str(uuid.uuid4()), batch_size=AdaptiveBatchSize
         )
 
     def message_listener(self, message_handler: Callable):
@@ -43,7 +40,8 @@ class MQDaoMofka(MQDao):
         try:
             while True:
                 event = self.consumer.pull().wait()
-                message = json.loads(event.metadata)
+                # message = json.loads(event.metadata)
+                message = event.metadata
                 self.logger.debug(f"Received message: {message}")
                 if not message_handler(message):
                     break
@@ -67,7 +65,7 @@ class MQDaoMofka(MQDao):
         try:
             # self.logger.debug(f"Going to send Message:\n\t[BEGIN_MSG]{buffer}\n[END_MSG]\t")
             for m in buffer:
-                self.producer.push(m)
+                self.producer.push(metadata=m)
 
         except Exception as e:
             self.logger.exception(e)
@@ -85,7 +83,7 @@ class MQDaoMofka(MQDao):
             # self.logger.debug(f"Going to send Message:\n\t[BEGIN_MSG]{buffer}\n[END_MSG]\t")
 
             for m in buffer:
-                self.producer.push(m)
+                self.producer.push(metadata=m)
                 total += len(str(m).encode())
 
         except Exception as e:
@@ -106,5 +104,11 @@ class MQDaoMofka(MQDao):
         return True
 
     def unsubscribe(self):
-        """Unsubscribes from Mofka topic."""
-        raise NotImplementedError()
+        """Stop pulling from the Mofka topic.
+
+        Mofka does not expose a topic-level unsubscribe like Kafka; the
+        subscription lifecycle is bound to the consumer object. Releasing
+        the reference here lets the underlying pymofka_client consumer
+        be cleaned up by GC.
+        """
+        self.consumer = None

--- a/src/flowcept/flowceptor/consumers/document_inserter.py
+++ b/src/flowcept/flowceptor/consumers/document_inserter.py
@@ -120,10 +120,17 @@ class DocumentInserter(BaseConsumer):
                 message["workflow_id"] = wf_id
 
         if "campaign_id" not in message:
+            # Try the KV-DAO-backed lookup, but only if the KV store is actually
+            # enabled. With kv_db.enabled=false in settings.yaml,
+            # self._mq_dao._keyvalue_dao is None and calling .get_key() on it
+            # raises AttributeError for every campaign_id-less message
+            # (notably @flowcept_torch per-batch model captures).
             try:
-                campaign_id = self._mq_dao._keyvalue_dao.get_key("current_campaign_id")
-                if campaign_id:
-                    message["campaign_id"] = campaign_id
+                kv_dao = getattr(self._mq_dao, "_keyvalue_dao", None)
+                if kv_dao is not None:
+                    campaign_id = kv_dao.get_key("current_campaign_id")
+                    if campaign_id:
+                        message["campaign_id"] = campaign_id
             except Exception as e:
                 self.logger.error(e)
 


### PR DESCRIPTION
Two small fixes encountered while bringing up the flowcept to mofka to mongo path against current `mofka@main`.

**1. `mq_dao_mofka.py`** -- adapt to current mofka Python API: `MofkaDriver` requires `group_file=` keyword and no longer takes `use_progress_thread`; producer and consumer no longer take `thread_pool`; `event.metadata` is already decoded (no `json.loads`); `producer.push()` requires the `metadata=` keyword. Also replaced `unsubscribe()`'s `NotImplementedError` with `self.consumer = None` (mofka has no topic-level unsubscribe; releasing the consumer ref is the right cleanup) since the old version crashed clean shutdown.

**2. `document_inserter.py`** -- guard the `_keyvalue_dao.get_key(...)` call with `getattr(..., None)` and `if kv_dao is not None:`. When `kv_db.enabled=false` (the default in `sample_settings.yaml`) `_keyvalue_dao` is `None`, and every message without a `campaign_id` was raising `AttributeError`. Semantics unchanged when KV DB is enabled. Happy to switch to a different pattern if preferred.

**Testing:** end-to-end smoke test (mongod + bedrock + flowcept consumer + 3-task `@flowcept_task` workload) on Improv against `mofka@main`, `kv_db.enabled=false`. All 3 tasks land in mongo, no errors.